### PR TITLE
Detect only really matters for the 1st party buildpacks

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,8 +1,4 @@
 #!/bin/bash
 
-if [ -f $1/src/main.cr ]; then
-  echo "Crystal"
-  exit 0
-else
-  exit 1
-fi
+echo "Crystal"
+exit 0


### PR DESCRIPTION
The only way someone is using this is with BUILDPACK_URL or the mutlibuildpack. In either case you want to run the buildpack.

The detect step is really just for when we have to differentiate between the first-party supported langs, when you don't set a BUILDPACK_URL
