### PR TITLE
Shards and latest crystal support, for good

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,0 +1,10 @@
+# Crystal Heroku Buildpack
+
+You can create an app in Heroku with Crystal's buildpack by running the
+following command:
+
+```bash
+$ heroku create myapp --buildpack https://github.com/zamith/heroku-buildpack-crystal.git
+```
+
+To learn more about using custom buildpacks in Heroku, read [theirs docs](https://devcenter.heroku.com/articles/third-party-buildpacks#using-a-custom-buildpack).

--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ following command:
 $ heroku create myapp --buildpack https://github.com/zamith/heroku-buildpack-crystal.git
 ```
 
-In order for the buildpack to work properly you should have a `Projectfile`
+In order for the buildpack to work properly you should have a `shard.yml`
 file, as it is how it will detect that your app is a Crystal app.
 
 To learn more about using custom buildpacks in Heroku, read [their docs](https://devcenter.heroku.com/articles/third-party-buildpacks#using-a-custom-buildpack).

--- a/README.markdown
+++ b/README.markdown
@@ -10,4 +10,4 @@ $ heroku create myapp --buildpack https://github.com/zamith/heroku-buildpack-cry
 In order for the buildpack to work properly you should have a `Projectfile`
 file, as it is how it will detect that your app is a Crystal app.
 
-To learn more about using custom buildpacks in Heroku, read [theirs docs](https://devcenter.heroku.com/articles/third-party-buildpacks#using-a-custom-buildpack).
+To learn more about using custom buildpacks in Heroku, read [their docs](https://devcenter.heroku.com/articles/third-party-buildpacks#using-a-custom-buildpack).

--- a/README.markdown
+++ b/README.markdown
@@ -7,4 +7,7 @@ following command:
 $ heroku create myapp --buildpack https://github.com/zamith/heroku-buildpack-crystal.git
 ```
 
+In order for the buildpack to work properly you should have a `Projectfile`
+file, as it is how it will detect that your app is a Crystal app.
+
 To learn more about using custom buildpacks in Heroku, read [theirs docs](https://devcenter.heroku.com/articles/third-party-buildpacks#using-a-custom-buildpack).

--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ To learn more about using custom buildpacks in Heroku, read [their docs](https:/
 
 ## Older versions of Crystal
 
-If you have and older version of Crystal (`>= 0.9`), that uses the old
+If you have and older version of Crystal (`<= 0.9`), that uses the old
 `Projectfile` way of handling dependencies, you can use
 [version 1.0](https://github.com/zamith/heroku-buildpack-crystal/tree/v1.0.0) of
 the buildpack.

--- a/README.markdown
+++ b/README.markdown
@@ -11,3 +11,10 @@ In order for the buildpack to work properly you should have a `shard.yml`
 file, as it is how it will detect that your app is a Crystal app.
 
 To learn more about using custom buildpacks in Heroku, read [their docs](https://devcenter.heroku.com/articles/third-party-buildpacks#using-a-custom-buildpack).
+
+## Older versions of Crystal
+
+If you have and older version of Crystal (`>= 0.9`), that uses the old
+`Projectfile` way of handling dependencies, you can use
+[version 1.0](https://github.com/zamith/heroku-buildpack-crystal/tree/v1.0.0) of
+the buildpack.

--- a/README.markdown
+++ b/README.markdown
@@ -4,17 +4,17 @@ You can create an app in Heroku with Crystal's buildpack by running the
 following command:
 
 ```bash
-$ heroku create myapp --buildpack https://github.com/zamith/heroku-buildpack-crystal.git
+$ heroku create myapp --buildpack https://github.com/manastech/heroku-buildpack-crystal.git
 ```
 
 In order for the buildpack to work properly you should have a `shard.yml`
 file, as it is how it will detect that your app is a Crystal app.
+
+The default behaviour is to use the [latest crystal release](https://github.com/crystal-lang/crystal/releases/latest). If you need to use a specific version create a `.crystal-version` file in your application root directory with the version that should be used (e.g. `0.17.1`).
 
 To learn more about using custom buildpacks in Heroku, read [their docs](https://devcenter.heroku.com/articles/third-party-buildpacks#using-a-custom-buildpack).
 
 ## Older versions of Crystal
 
 If you have and older version of Crystal (`<= 0.9`), that uses the old
-`Projectfile` way of handling dependencies, you can use
-[version 1.0](https://github.com/zamith/heroku-buildpack-crystal/tree/v1.0.0) of
-the buildpack.
+`Projectfile` way of handling dependencies, please upgrade :-).

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.9.0/crystal-0.9.0-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.9.1/crystal-0.9.1-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL=https://github.com/manastech/crystal/tarball/master
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.5.8/crystal-0.5.8-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.7.2/crystal-0.7.2-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.7.4/crystal-0.7.4-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+# YAML parser from https://gist.github.com/pkuczynski/8665367
+parse_yaml() {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}
+
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
@@ -18,7 +35,13 @@ cd $BUILD_DIR
 if [ -f shard.yml ]; then
   echo "-----> Installing Dependencies"
   $CRYSTAL_DIR/bin/crystal deps
+
+  eval $(parse_yaml shard.yml "shard_")
+
+  echo "-----> Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
+  $CRYSTAL_DIR/bin/crystal build src/${shard_name}.cr --release -o app
+else
+  echo "-----> Compiling app.cr (defaulted - set name in shard.yml to override)"
+  $CRYSTAL_DIR/bin/crystal build app.cr --release
 fi
 
-echo "-----> Compiling app.cr"
-$CRYSTAL_DIR/bin/crystal build app.cr --release

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.7.4/crystal-0.7.4-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.7.5/crystal-0.7.5-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.8.0/crystal-0.8.0-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.9.0/crystal-0.9.0-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+# YAML parser from https://gist.github.com/pkuczynski/8665367
+parse_yaml() {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}
+
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
@@ -18,7 +35,17 @@ cd $BUILD_DIR
 if [ -f shard.yml ]; then
   echo "-----> Installing Dependencies"
   $CRYSTAL_DIR/bin/crystal deps
+
+  if [ -f app.cr ]; then
+    printf "-----> DEPRECATED: Your main file should have the name of your shard and not app.cr.\nCompiling app.cr"
+    $CRYSTAL_DIR/bin/crystal build app.cr --release
+  else
+    eval $(parse_yaml shard.yml "shard_")
+    echo "-----> Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
+    $CRYSTAL_DIR/bin/crystal build src/${shard_name}.cr --release -o app
+  fi
+else
+  printf "-----> DEPRECATED: You are using an old version of the dependency manager, please look at https://github.com/ysbaddaden/shards for information on the currently advised method.\nCompiling app.cr"
+  $CRYSTAL_DIR/bin/crystal build app.cr --release
 fi
 
-echo "-----> Compiling app.cr"
-$CRYSTAL_DIR/bin/crystal build app.cr --release

--- a/bin/compile
+++ b/bin/compile
@@ -10,8 +10,7 @@ unset GIT_DIR
 # Install Crystal
 echo "-----> Installing Crystal"
 mkdir -p $CRYSTAL_DIR
-cd $CRYSTAL_DIR
-curl -sL $CRYSTAL_URL | tar xz --strip-component=1
+curl -sL $CRYSTAL_URL | tar xz -C $CRYSTAL_DIR --strip-component=1
 
 # Build the project
 cd $BUILD_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -21,9 +21,7 @@ if [ -f Projectfile ]; then
 fi
 
 echo "-----> CRYSTAL_DIR"
-echo $(ls $CRYSTAL_DIR)
-echo "-----> BUILD_DIR"
-echo $(ls)
+echo $(ls $CRYSTAL_DIR/bin)
 
 echo "-----> Compiling app.cr"
 $CRYSTAL_DIR/bin/crystal build app.cr --release

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.10.0/crystal-0.10.0-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.10.2/crystal-0.10.2-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,7 @@ parse_yaml() {
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.11.1/crystal-0.11.1-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.12.0/crystal-0.12.0-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -36,10 +36,14 @@ if [ -f shard.yml ]; then
   echo "-----> Installing Dependencies"
   $CRYSTAL_DIR/bin/crystal deps
 
-  eval $(parse_yaml shard.yml "shard_")
-
-  echo "-----> Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
-  $CRYSTAL_DIR/bin/crystal build src/${shard_name}.cr --release -o app
+  if [ -f app.cr ]; then
+    echo "-----> Compiling app.cr (overriden - app.cr exists)"
+    $CRYSTAL_DIR/bin/crystal build app.cr --release
+  else
+    eval $(parse_yaml shard.yml "shard_")
+    echo "-----> Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
+    $CRYSTAL_DIR/bin/crystal build src/${shard_name}.cr --release -o app
+  fi
 else
   echo "-----> Compiling app.cr (defaulted - set name in shard.yml to override)"
   $CRYSTAL_DIR/bin/crystal build app.cr --release

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.5.8/crystal-0.5.8-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.5.9/crystal-0.5.9-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -20,5 +20,10 @@ if [ -f Projectfile ]; then
   $CRYSTAL_DIR/bin/crystal deps
 fi
 
+echo "-----> CRYSTAL_DIR"
+echo $(ls $CRYSTAL_DIR)
+echo "-----> BUILD_DIR"
+echo $(ls)
+
 echo "-----> Compiling app.cr"
 $CRYSTAL_DIR/bin/crystal build app.cr --release

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.7.7/crystal-0.7.7-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.8.0/crystal-0.8.0-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/crystal-lang/crystal/releases/download/0.13.0/crystal-0.13.0-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/crystal-lang/crystal/releases/download/0.15.0/crystal-0.15.0-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -17,15 +17,30 @@ parse_yaml() {
    }'
 }
 
+function json_value() {
+  KEY=$1
+  num=$2
+  awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/\042'$KEY'\042/){print $(i+1)}}}' | tr -d ' "' | sed -n ${num}p
+}
+
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/crystal-lang/crystal/releases/download/0.15.0/crystal-0.15.0-1-linux-x86_64.tar.gz"
+
+if [ -f $BUILD_DIR/.crystal-version ]; then
+  CRYSTAL_VERSION=`cat $BUILD_DIR/.crystal-version | tr -d '\012'`
+  CRYSTAL_VERSION_REASON='due to .crystal-version file'
+else
+  CRYSTAL_VERSION=`curl -s https://api.github.com/repos/crystal-lang/crystal/releases/latest | json_value tag_name 1 | tr -d '\012'`
+  CRYSTAL_VERSION_REASON='due to latest release at https://github.com/crystal-lang/crystal'
+fi
+
+CRYSTAL_URL="https://github.com/crystal-lang/crystal/releases/download/$CRYSTAL_VERSION/crystal-$CRYSTAL_VERSION-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 
 # Install Crystal
-echo "-----> Installing Crystal"
+echo "-----> Installing Crystal ($CRYSTAL_VERSION $CRYSTAL_VERSION_REASON)"
 mkdir -p $CRYSTAL_DIR
 curl -sL $CRYSTAL_URL | tar xz -C $CRYSTAL_DIR --strip-component=1
 

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.5.9/crystal-0.5.9-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.6.1/crystal-0.6.1-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.10.2/crystal-0.10.2-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.11.1/crystal-0.11.1-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -20,5 +20,5 @@ if [ -f Projectfile ]; then
   $CRYSTAL_DIR/bin/crystal deps
 fi
 
-echo "-----> Compiling src/main.cr"
-$CRYSTAL_DIR/bin/crystal build src/main.cr --release
+echo "-----> Compiling app.cr"
+$CRYSTAL_DIR/bin/crystal build app.cr --release

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.11.1/crystal-0.11.1-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/crystal-lang/crystal/releases/download/0.13.0/crystal-0.13.0-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,8 @@ unset GIT_DIR
 # Install Crystal
 echo "-----> Installing Crystal"
 mkdir -p $CRYSTAL_DIR
-curl -sL $CRYSTAL_URL | tar xz -C $CRYSTAL_DIR
+cd $CRYSTAL_DIR
+curl -sL $CRYSTAL_URL | tar xz --strip-component=1
 
 # Build the project
 cd $BUILD_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL=http://dist.crystal-lang.org/crystal-latest-linux-x86_64.tar.gz
+CRYSTAL_URL=https://github.com/manastech/crystal/tarball/master
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.7.5/crystal-0.7.5-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.7.6/crystal-0.7.6-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,7 @@ unset GIT_DIR
 # Install Crystal
 echo "-----> Installing Crystal"
 mkdir -p $CRYSTAL_DIR
-curl -sL $CRYSTAL_URL | tar xz -C $CRYSTAL_DIR --strip-components=1
+curl -sL $CRYSTAL_URL | tar xz -C $CRYSTAL_DIR
 
 # Build the project
 cd $BUILD_DIR
@@ -19,9 +19,6 @@ if [ -f Projectfile ]; then
   echo "-----> Installing Dependencies"
   $CRYSTAL_DIR/bin/crystal deps
 fi
-
-echo "-----> CRYSTAL_DIR"
-echo $(ls $CRYSTAL_DIR/bin)
 
 echo "-----> Compiling app.cr"
 $CRYSTAL_DIR/bin/crystal build app.cr --release

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.7.6/crystal-0.7.6-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.7.7/crystal-0.7.7-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.6.1/crystal-0.6.1-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.7.2/crystal-0.7.2-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.9.1/crystal-0.9.1-1-linux-x86_64.tar.gz"
+CRYSTAL_URL="https://github.com/manastech/crystal/releases/download/0.10.0/crystal-0.10.0-1-linux-x86_64.tar.gz"
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 
@@ -15,7 +15,7 @@ curl -sL $CRYSTAL_URL | tar xz -C $CRYSTAL_DIR --strip-component=1
 # Build the project
 cd $BUILD_DIR
 
-if [ -f Projectfile ]; then
+if [ -f shard.yml ]; then
   echo "-----> Installing Dependencies"
   $CRYSTAL_DIR/bin/crystal deps
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,7 @@ if [ -f shard.yml ]; then
   $CRYSTAL_DIR/bin/crystal deps
 
   if [ -f app.cr ]; then
-    echo "-----> Compiling app.cr (overriden - app.cr exists)"
+    echo "-----> Compiling app.cr (using old behaviour, app.cr exists - ignoring shard.yml)"
     $CRYSTAL_DIR/bin/crystal build app.cr --release
   else
     eval $(parse_yaml shard.yml "shard_")
@@ -45,7 +45,7 @@ if [ -f shard.yml ]; then
     $CRYSTAL_DIR/bin/crystal build src/${shard_name}.cr --release -o app
   fi
 else
-  echo "-----> Compiling app.cr (defaulted - set name in shard.yml to override)"
+  echo "-----> Compiling app.cr (create shard.yml to override, learn more: https://github.com/ysbaddaden/shards)"
   $CRYSTAL_DIR/bin/crystal build app.cr --release
 fi
 

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -f $1/Projectfile ]; then
+if [ -f $1/shard.yml ]; then
   echo "Crystal"
   exit 0
 else

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -f $1/src/main.cr ]; then
+if [ -f $1/Projectfile ]; then
   echo "Crystal"
   exit 0
 else

--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,5 @@ cat << EOF
 ---
 addons:
 default_process_types:
-  web: ./main --port \$PORT
+  web: ./app --port \$PORT
 EOF


### PR DESCRIPTION
Fixes #2. Supersedes #3 

This merge the contributions from @zamith, @ukd1 repositories. 

`shards.yml` will be used to detect if dependencies should be installed.
`shards.yml` will be used to detect main source file. otherwise app.cr is used
github latest release will be used by default.
If you need to use a specific version create a `.crystal-version` at the app root.

@zamith / @ukd1 sorry for the enormous delay. If you can give a 👍 we will merge this.

@asterite, later this could be migrated to crystal-lang org, WDYT?

My apologies for the ugly bash things done, but I want to avoid the "update to crystal version" maintenance commits.
