### PR TITLE
crystal deps should only install production

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,7 @@ cd $BUILD_DIR
 
 if [ -f shard.yml ]; then
   echo "-----> Installing Dependencies"
-  $CRYSTAL_DIR/bin/crystal deps
+  $CRYSTAL_DIR/bin/crystal deps --production
 
   if [ -f app.cr ]; then
     echo "-----> Compiling app.cr (using old behaviour, app.cr exists - ignoring shard.yml)"


### PR DESCRIPTION
Added `--production` flag to skip installing `development_dependencies` from shard.yml file.