### PR TITLE
remove dead code

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -47,20 +47,14 @@ curl -sL $CRYSTAL_URL | tar xz -C $CRYSTAL_DIR --strip-component=1
 # Build the project
 cd $BUILD_DIR
 
-if [ -f shard.yml ]; then
-  echo "-----> Installing Dependencies"
-  $CRYSTAL_DIR/bin/crystal deps --production
+echo "-----> Installing Dependencies"
+$CRYSTAL_DIR/bin/crystal deps --production
 
-  if [ -f app.cr ]; then
-    echo "-----> Compiling app.cr (using old behaviour, app.cr exists - ignoring shard.yml)"
-    $CRYSTAL_DIR/bin/crystal build app.cr --release
-  else
-    eval $(parse_yaml shard.yml "shard_")
-    echo "-----> Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
-    $CRYSTAL_DIR/bin/crystal build src/${shard_name}.cr --release -o app
-  fi
-else
-  echo "-----> Compiling app.cr (create shard.yml to override, learn more: https://github.com/ysbaddaden/shards)"
+if [ -f app.cr ]; then
+  echo "-----> Compiling app.cr (using old behaviour, app.cr exists - ignoring shard.yml)"
   $CRYSTAL_DIR/bin/crystal build app.cr --release
+else
+  eval $(parse_yaml shard.yml "shard_")
+  echo "-----> Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
+  $CRYSTAL_DIR/bin/crystal build src/${shard_name}.cr --release -o app
 fi
-


### PR DESCRIPTION
shard.yml is *required* for bin/detect to succeed, so this extra branching logic is unnecessary.