### PR TITLE
Add `set -e` to the compile script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 steptxt="----->"
 
 start() {


### PR DESCRIPTION
This ensures that if compilation fails the buildpack doesn't continue
the deploy and deploy a version to heroku that has no executable.

Tested by:
  - creating a commit in a heroku test app that has a syntax error in
    its crystal code
  - committing and running `git push heroku HEAD:master`
  - verifying the heroku build fails when compilation of the crystal
    code fails (previously it would continue and create a new version)