### PR TITLE
Discover asset url

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 steptxt="----->"
 

--- a/bin/compile
+++ b/bin/compile
@@ -47,13 +47,13 @@ else
   CRYSTAL_VERSION_REASON='due to latest release at https://github.com/crystal-lang/crystal'
 fi
 
-CRYSTAL_URL="https://github.com/crystal-lang/crystal/releases/download/$CRYSTAL_VERSION/crystal-$CRYSTAL_VERSION-1-linux-x86_64.tar.gz"
+CRYSTAL_URL=`${CURL} https://api.github.com/repos/crystal-lang/crystal/releases/tags/${CRYSTAL_VERSION} | grep 'https://github.com/crystal-lang/crystal/releases/download/.*-linux-x86_64.tar.gz' | sed 's/.*: "\(.*\)"/\1/'`
 CRYSTAL_DIR=/tmp/crystal
 unset GIT_DIR
 
 # Install Crystal
 mkdir -p $CRYSTAL_DIR
-start "Installing Crystal ($CRYSTAL_VERSION $CRYSTAL_VERSION_REASON)"
+start "Installing Crystal ($CRYSTAL_VERSION $CRYSTAL_VERSION_REASON) from $CRYSTAL_URL"
   ${CURL} $CRYSTAL_URL | tar xz -C $CRYSTAL_DIR --strip-component=1
 finished
 PATH="${PATH}:${CRYSTAL_DIR}/bin"


### PR DESCRIPTION
We discover the tar.gz URL from Github's Releases API. In addition, make the build fail if any step of the build script errors.

It's been tested both with 0.23.1 (`-3`) and 0.18.0 (`-1`).

Fixes #23