### PR TITLE
Build with --no-debug when available

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -65,13 +65,15 @@ start "Installing Dependencies"
   crystal deps --production
 finished
 
+NO_DEBUG_IF_AVAILABLE=`crystal build --help | grep -q -- --no-debug && echo -n --no-debug`
+
 if [ -f app.cr ]; then
   start "Compiling app.cr (using old behaviour, app.cr exists - ignoring shard.yml)"
-    crystal build app.cr --release
+    crystal build app.cr --release $NO_DEBUG_IF_AVAILABLE
   finished
 else
   eval $(parse_yaml shard.yml "shard_")
   start "Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
-    crystal build src/${shard_name}.cr --release -o app
+    crystal build src/${shard_name}.cr --release $NO_DEBUG_IF_AVAILABLE -o app
   finished
 fi


### PR DESCRIPTION
Builds are done with `--release`, so it makes sense to add `--no-debug` as well. In addition, Crystal 0.23.x is having issues without `--no-debug`, so the buildpack can workaround it until its solved.