### PR TITLE
 Disable use of the --no-debug if desired

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -69,7 +69,7 @@ finished
 
 # Compile with --no-debug if supported unless the DEBUG_ENABLE var is set
 if ! [ -n DEBUG_ENABLED ]; then
-  DEBUG_FLAGS=`crystal build --help | grep -q -- --no-debug && echo -n --no-debug`
+  DEBUG_FLAGS=`crystal build --help | grep -q -- --no-debug && echo --release -n --no-debug`
 fi
 
 if [ -f app.cr ]; then
@@ -79,6 +79,6 @@ if [ -f app.cr ]; then
 else
   eval $(parse_yaml shard.yml "shard_")
   start "Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
-    crystal build src/${shard_name}.cr --release -o app $DEBUG_FLAGS
+    crystal build src/${shard_name}.cr -o app $DEBUG_FLAGS
   finished
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -70,6 +70,11 @@ finished
 # Compile with --no-debug if supported unless the DEBUG_ENABLE var is set
 if ! [ -n DEBUG_ENABLED ]; then
   DEBUG_FLAGS=`crystal build --help | grep -q -- --no-debug && echo --release -n --no-debug`
+else
+  echo -n "####################################### DEBUGGING ENABLED #######################################"
+  echo -n "Debugging has been enabled, at the cost of performance. This will not be a fully optimized build."
+  echo -n "Unset the DEBUG_ENABLED environment variable to disable debugging"
+  echo -n "#################################################################################################"
 fi
 
 if [ -f app.cr ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -67,7 +67,12 @@ start "Installing Dependencies"
   crystal deps --production
 finished
 
-NO_DEBUG_IF_AVAILABLE=`crystal build --help | grep -q -- --no-debug && echo -n --no-debug`
+NO_DEBUG_IF_AVAILABLE=""
+
+# Compile with --no-debug if supported unless the DEBUG_ENABLE var is set
+if [[ !-n DEBUG_ENABLED ]]; then
+  NO_DEBUG_IF_AVAILABLE=`crystal build --help | grep -q -- --no-debug && echo -n --no-debug`
+fi
 
 if [ -f app.cr ]; then
   start "Compiling app.cr (using old behaviour, app.cr exists - ignoring shard.yml)"


### PR DESCRIPTION
Compile the application without the --no-debug flag if the DEBUG_ENABLED env variable is set, making debugging optional.

Use case:
I have an application that has an exception being raised on heroku only. The exception could be coming from a number of places, so without debug information, it is very difficult to determine where this bug is coming from.