### PR TITLE
Build targets from shards.yml

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -73,6 +73,10 @@ if [ -f app.cr ]; then
   start "Compiling app.cr (using old behaviour, app.cr exists - ignoring shard.yml)"
     crystal build app.cr --release $NO_DEBUG_IF_AVAILABLE
   finished
+elif [ -f "shard.yml" ]; then
+  start "Compiling targets"
+    shards build --release $NO_DEBUG_IF_AVAILABLE
+  finished
 else
   eval $(parse_yaml shard.yml "shard_")
   start "Compiling src/${shard_name}.cr (auto-detected from shard.yml)"


### PR DESCRIPTION
Sometimes multiple target is needed. `bin/compile` should build all of it's targets.