### PR TITLE
Use shards build and no default process

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -63,19 +63,6 @@ PATH="${PATH}:${CRYSTAL_DIR}/bin:${CRYSTAL_DIR}/embedded/bin/"
 # Build the project
 cd $BUILD_DIR
 
-start "Installing Dependencies"
-  shards --production
+start "Compiling"
+  shards build --release --production
 finished
-
-NO_DEBUG_IF_AVAILABLE=`crystal build --help | grep -q -- --no-debug && echo -n --no-debug`
-
-if [ -f app.cr ]; then
-  start "Compiling app.cr (using old behaviour, app.cr exists - ignoring shard.yml)"
-    crystal build app.cr --release $NO_DEBUG_IF_AVAILABLE
-  finished
-else
-  eval $(parse_yaml shard.yml "shard_")
-  start "Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
-    crystal build src/${shard_name}.cr --release $NO_DEBUG_IF_AVAILABLE -o app
-  finished
-fi

--- a/bin/compile
+++ b/bin/compile
@@ -63,6 +63,4 @@ PATH="${PATH}:${CRYSTAL_DIR}/bin:${CRYSTAL_DIR}/embedded/bin/"
 # Build the project
 cd $BUILD_DIR
 
-start "Compiling"
-  shards build --release --production
-finished
+shards build --release --production

--- a/bin/compile
+++ b/bin/compile
@@ -41,6 +41,11 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
+export LIBRARY_PATH=/app/.heroku/vendor/lib:$BUILD_DIR/.heroku/vendor/lib:/app/.heroku/python/lib:$LIBRARY_PATH
+export LD_LIBRARY_PATH=/app/.heroku/vendor/lib:$BUILD_DIR/.heroku/vendor/lib:/app/.heroku/python/lib:$LD_LIBRARY_PATH
+export PKG_CONFIG_PATH=/app/.heroku/vendor/lib/pkg-config:$BUILD_DIR/.heroku/vendor/lib/pkg-config:/app/.heroku/python/lib/pkg-config:$PKG_CONFIG_PATH
+
+
 if [ -f $BUILD_DIR/.crystal-version ]; then
   CRYSTAL_VERSION=`cat $BUILD_DIR/.crystal-version | tr -d '\012'`
   CRYSTAL_VERSION_REASON='due to .crystal-version file'

--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,4 @@ cat << EOF
 ---
 addons:
 default_process_types:
-  web: ./app --port \$PORT
 EOF


### PR DESCRIPTION
Simply running `shards build --release --production` and then using a proper `Procfile` where you define your process, instead of this weird hard coded "app" process. 

Also don't remove debug information as it might be vital to recover in case of bugs/crashes. 